### PR TITLE
Ensure that fake required fields work as expected

### DIFF
--- a/templates/input/form-element-label.html.twig
+++ b/templates/input/form-element-label.html.twig
@@ -32,6 +32,13 @@
     required ? 'js-form-required',
   ]
 %}
+{#
+  If there label already has the class 'js-form-required' then set the boolean
+  as expected. See \Drupal\commerce_authnet\PluginForm\AcceptJs\PaymentMethodAddForm::buildCreditCardForm().
+#}
+{%
+  set required = attributes.hasClass('js-form-required')
+%}
 {% if title is not empty %}
   <label{{ attributes.addClass(classes) }}>{{ element }}{{ title }}
     {% if required and (title_display == 'before' or title_display == 'after') %}

--- a/templates/input/form-element-label.html.twig
+++ b/templates/input/form-element-label.html.twig
@@ -33,7 +33,7 @@
   ]
 %}
 {#
-  If there label already has the class 'js-form-required' then set the boolean
+  If the label already has the class 'js-form-required' then set the boolean
   as expected. See \Drupal\commerce_authnet\PluginForm\AcceptJs\PaymentMethodAddForm::buildCreditCardForm().
 #}
 {%


### PR DESCRIPTION
Some fields fake being required so that browsers behave as expected and the fields have the little asterisk. The customisations in templates/input/form-element-label.html.twig break this. See https://git.drupalcode.org/project/commerce_authnet/blob/8.x-1.x/src/PluginForm/AcceptJs/PaymentMethodAddForm.php#L42 for an important example.